### PR TITLE
Proposal of review of basic fee_rate values for faircoin 2

### DIFF
--- a/electrumfair.conf.sample
+++ b/electrumfair.conf.sample
@@ -12,5 +12,5 @@ use_change = True
 gui = qt
 num_zeros = 2
 # default transaction fee is in Satoshis
-fee = 10000
+fee = 1000000
 winpos-qt = [799, 226, 877, 435]

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -42,7 +42,7 @@ class SimpleConfig(PrintError):
         # a thread-safe way.
         self.lock = threading.RLock()
 
-        self.transaction_fee = 0.1 # let's have a reasonable start value
+        self.transaction_fee = 1000000 # let's have a reasonable start value
 
         # The following two functions are there for dependency injection when
         # testing.

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -785,8 +785,8 @@ class Abstract_Wallet(PrintError):
         return status, status_str
 
     def relayfee(self):
-        RELAY_FEE = 5000
-        MAX_RELAY_FEE = 50000
+        RELAY_FEE = 1000000
+        MAX_RELAY_FEE = 20000000
         f = self.network.relay_fee if self.network and self.network.relay_fee else RELAY_FEE
         return min(f, MAX_RELAY_FEE)
 


### PR DESCRIPTION
This is just a proposal for updating the default values of fee rate to something nearer to current values. Of course, the wallet will calculate the fee requesting the fee rate to the electrumfair server, but trying to aproach to reality in the harcoded values in code.
Not sure if SimpleConfig.transaction_fee = 1000000 is a good default value. The same with others.
Don't take this PR really seriously, it's just a proposal and no problem at all if closing it without merge.