### PR TITLE
Add the packaging metadata to build the electrumfair snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: electrumfair
+version: 2.8.3-fc
+summary: FairCoin thin client
+description: |
+  Lightweight FairCoin client
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  electrumfair:
+    command: desktop-launch electrumfair
+    plugs: [network, network-bind, x11, unity7]
+
+parts:
+  electrum:
+    source: .
+    plugin: python
+    python-version: python2
+    stage-packages: [python-qt4]
+    build-packages: [pyqt4-dev-tools]
+    install: pyrcc4 icons.qrc -o $SNAPCRAFT_PART_INSTALL/lib/python2.7/site-packages/electrumfair_gui/qt/icons_rc.py
+    after: [desktop-qt4]


### PR DESCRIPTION
This package will let you publish the latest electrumfair in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.